### PR TITLE
hotfix: fix CSP to allow Google Analytics regional domains

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,7 +26,7 @@ const { title, description = "Engineering Leader | Fintech Builder | Travel Opti
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://www.google-analytics.com https://analytics.google.com" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://*.google-analytics.com https://*.analytics.google.com" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 
     <!-- SEO Meta Tags -->


### PR DESCRIPTION
🔐 CSP Fix:
- Add wildcard support for Google Analytics domains (*.google-analytics.com)
- Allow regional endpoints like region1.google-analytics.com
- Fixes CSP violations blocking GA4 data collection
- Enables proper analytics tracking functionality

🎯 Resolves Console Errors:
- Eliminates 'Refused to connect' CSP blocking errors
- Allows gtag script to load and initialize properly
- Enables analytics events to fire correctly