### PR TITLE
hotfix: improve gtag timing mechanism with multiple retries

### DIFF
--- a/src/components/AnalyticsEvents.astro
+++ b/src/components/AnalyticsEvents.astro
@@ -9,17 +9,26 @@
     (function() {
       'use strict';
 
-      // Enhanced safety check - wait for gtag to be available
-      if (typeof gtag === 'undefined') {
-        // Retry after a short delay if gtag isn't ready yet
-        setTimeout(() => {
-          if (typeof gtag !== 'undefined') {
-            console.log('Enhanced Analytics: gtag loaded, initializing...');
-            initializeTracking();
-          } else {
-            console.warn('Enhanced Analytics: gtag not available, skipping');
-          }
-        }, 1000);
+      // Enhanced safety check - wait for gtag to be available with multiple retries
+      const waitForGtag = (attempt = 1, maxAttempts = 10) => {
+        if (typeof gtag !== 'undefined' && window.dataLayer) {
+          console.log(`Enhanced Analytics: gtag and dataLayer loaded on attempt ${attempt}, initializing...`);
+          initializeTracking();
+          return;
+        }
+
+        if (attempt < maxAttempts) {
+          const delay = attempt * 500; // Increasing delay: 500ms, 1s, 1.5s, etc.
+          console.log(`Enhanced Analytics: gtag not ready, retrying in ${delay}ms (attempt ${attempt}/${maxAttempts})`);
+          setTimeout(() => waitForGtag(attempt + 1, maxAttempts), delay);
+        } else {
+          console.warn('Enhanced Analytics: gtag not available after all retries, skipping');
+        }
+      };
+
+      if (typeof gtag === 'undefined' || !window.dataLayer) {
+        console.log('Enhanced Analytics: gtag or dataLayer not ready, waiting...');
+        waitForGtag();
         return;
       }
 


### PR DESCRIPTION
🕐 Enhanced Timing Strategy:
- Add multiple retry attempts (up to 10) with increasing delays
- Check both gtag function AND dataLayer availability
- Progressive delay: 500ms, 1s, 1.5s, 2s, etc.
- Detailed logging for each retry attempt

🔧 Improvements:
- More robust detection of Google Analytics readiness
- Better debugging with attempt counter and delays
- Handles slow-loading GA scripts more effectively
- Graceful fallback after all retry attempts

🎯 Resolves:
- gtag not available timing issues
- Ensures proper GA initialization before event tracking
- Provides clear console feedback for debugging